### PR TITLE
Do not fail on vboxnet interface

### DIFF
--- a/ext/rb_getifaddrs/rb_getifaddrs.c
+++ b/ext/rb_getifaddrs/rb_getifaddrs.c
@@ -18,6 +18,8 @@ VALUE ipaddr(struct sockaddr *ip) {
     VALUE bytes;
 
     switch(ip->sa_family) {
+    // VirtualBox vboxnet interface does not specify family
+    case AF_UNSPEC:
     case AF_INET:
         bytes = rb_str_new(&((struct sockaddr_in *)ip)->sin_addr.s_addr, 4);
         break;
@@ -27,7 +29,7 @@ VALUE ipaddr(struct sockaddr *ip) {
         break;
 
     default:
-        rb_raise(rb_eSystemCallError, "Unhandled IP family.");
+        rb_raise(rb_eSystemCallError, "Unhandled IP family %i.", ip->sa_family);
 
     }
 


### PR DESCRIPTION
VirtualBox vboxnet interface doesn't specify family, and make system-getifaddrs gem fail with error:
`get_all_ifaddrs': unknown error - Unhandled IP family. (SystemCallError)

This modification fixes it.
