### PR TITLE
Fix loading of native extension

### DIFF
--- a/lib/system/getifaddrs.rb
+++ b/lib/system/getifaddrs.rb
@@ -1,9 +1,5 @@
 require 'ipaddr'
-begin
-  require File.join(File.dirname(__FILE__), 'rb_getifaddrs')
-rescue LoadError
-  require File.join(File.dirname(__FILE__), '..', 'rb_getifaddrs')
-end
+require 'system/rb_getifaddrs'
 
 module System
   def self.get_ifaddrs

--- a/lib/system/getifaddrs/version.rb
+++ b/lib/system/getifaddrs/version.rb
@@ -1,5 +1,5 @@
 module System
   class Getifaddrs
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
I've been using this gem for a couple of years on Arch Linux (ARM).
Since Arch rolled to Ruby 2.7 this gem broke. Fix is in this fork. Same/similar fix was applied earlier in other forks as well, so this seemed to break earlier in other setups as well.